### PR TITLE
fix: 프로젝트 상세 페이지 에러 수정

### DIFF
--- a/src/components/project/Detail/DeveloperInfo.style.tsx
+++ b/src/components/project/Detail/DeveloperInfo.style.tsx
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 
+
 interface Span4Props {
     isLoggedIn: boolean;
 }
@@ -85,13 +86,11 @@ export const Span4 = styled.span<Span4Props>`
     font-weight: 500;
     color: var(--grey-800);
     background-color: white;
-    ${props =>
-        props.isLoggedIn &&
-        css`
-            &:hover {
-                background-color: #f2f2f2;
-            }
-        `}
+    ${props => props.isLoggedIn && css`
+        &:hover {
+            background-color: #f2f2f2;
+        }
+    `}
 `;
 
 export const Members = styled.div`

--- a/src/components/project/Detail/DeveloperInfo.tsx
+++ b/src/components/project/Detail/DeveloperInfo.tsx
@@ -1,10 +1,4 @@
-import {
-    FunctionComponent,
-    useState,
-    useEffect,
-    useMemo,
-    useCallback,
-} from 'react';
+import { FunctionComponent, useState, useEffect, useMemo, useCallback } from 'react';
 import * as D from './DeveloperInfo.style';
 import { useAuth } from '../../../hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
@@ -60,8 +54,7 @@ const DeveloperInfo: FunctionComponent = () => {
 
     // 프로젝트 데이터 불러오기
     useEffect(() => {
-        axiosInstance
-            .get(`/api/v1/project/${projectId}`)
+        axiosInstance.get(`/api/v1/project/${projectId}`)
             .then(response => {
                 setProjectData(response.data.data);
                 setMembersData(response.data.data.members);
@@ -71,15 +64,12 @@ const DeveloperInfo: FunctionComponent = () => {
 
     const navigate = useNavigate(); // useNavigate 사용
 
-    const goToUserProfile = useCallback(
-        (userId: number) => {
-            // 로그인 상태일 때만 프로필 페이지로 이동
-            if (userinfo.isLogin) {
-                navigate(`/userpage/${userId}`);
-            }
-        },
-        [userinfo, navigate],
-    );
+    const goToUserProfile = useCallback((userId: number) => {
+        // 로그인 상태일 때만 프로필 페이지로 이동
+        if (userinfo.isLogin) {
+            navigate(`/userpage/${userId}`);
+        }
+    }, [userinfo, navigate]);
 
     // 각 역할별 멤버 매핑
     const mappedMembers = useMemo(() => {
@@ -89,7 +79,7 @@ const DeveloperInfo: FunctionComponent = () => {
             프론트: [],
             백: [],
             풀스텍: [],
-            팀원: [], //트랙 미기재
+            기타: [], //트랙 미기재
         };
         membersData.forEach(member => {
             const memberDetail = { name: member.name, userId: member.userId };
@@ -111,7 +101,7 @@ const DeveloperInfo: FunctionComponent = () => {
                     roleMapping.풀스텍.push(memberDetail);
                     break;
                 case 'NO_PART':
-                    roleMapping.팀원.push(memberDetail);
+                    roleMapping.기타.push(memberDetail);
                     break;
             }
         });
@@ -140,24 +130,21 @@ const DeveloperInfo: FunctionComponent = () => {
             <D.RightWrapper>
                 <D.Label>팀원 소개</D.Label>
                 <D.Members>
-                    {Object.keys(mappedMembers).map(
-                        part =>
-                            mappedMembers[part].length > 0 && (
-                                <p key={part}>
-                                    <D.Span>{part}</D.Span>
-                                    {mappedMembers[part].map(member => (
-                                        <D.Span4
-                                            isLoggedIn={userinfo.isLogin}
-                                            key={member.name}
-                                            onClick={() =>
-                                                goToUserProfile(member.userId)
-                                            }
-                                        >
-                                            {member.name}
-                                        </D.Span4>
-                                    ))}
-                                </p>
-                            ),
+                    {Object.keys(mappedMembers).map(part =>
+                        mappedMembers[part].length > 0 && (
+                            <p key={part}>
+                                <D.Span>{part}</D.Span>
+                                {mappedMembers[part].map(member => (
+                                    <D.Span4
+                                        isLoggedIn={userinfo.isLogin}
+                                        key={member.name}
+                                        onClick={() => goToUserProfile(member.userId)}
+                                    >
+                                        {member.name}
+                                    </D.Span4>
+                                ))}
+                            </p>
+                        )
                     )}
                 </D.Members>
             </D.RightWrapper>

--- a/src/components/project/Detail/ProjectDetail.tsx
+++ b/src/components/project/Detail/ProjectDetail.tsx
@@ -27,13 +27,11 @@ const ProjectDetail: FunctionComponent = () => {
         const pathParts = path.split('/');
         const projectId = pathParts[pathParts.length - 1];
 
-        axiosInstance
-            .get(`/api/v1/project/${projectId}`)
+        axiosInstance.get(`/api/v1/project/${projectId}`)
             .then(response => setProjectData(response.data.data))
-            .catch(error =>
-                console.error('Error fetching project data:', error),
-            );
+            .catch(error => console.error('Error fetching project data:', error));
     }, []);
+
 
     // 로딩 상태 확인
     if (!projectData) return <div>Loading...</div>;

--- a/src/components/project/Detail/Title.tsx
+++ b/src/components/project/Detail/Title.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback,useState,useEffect } from 'react';
 import * as T from './Title.style';
 import { ProjectData } from './ProjectDetail';
 import { RightArrow } from '../../../img/project/detail';
 import useInnerWidth from '../../../hooks/useInnerWidth';
 import styled from 'styled-components';
+
 
 interface TitleProps {
     projectData: ProjectData;
@@ -19,9 +20,7 @@ const ProjectSummary = styled.b<{ fontSize: string }>`
 `;
 
 function Title({ projectData }: TitleProps) {
-    const [summaryFontSize, setSummaryFontSize] = useState(
-        'var(--title-24-bold-size)',
-    ); // 초기 폰트 크기 설정
+    const [summaryFontSize, setSummaryFontSize] = useState('var(--title-24-bold-size)'); // 초기 폰트 크기 설정
 
     useEffect(() => {
         // 프로젝트 요약 길이에 따라 폰트 크기 조절
@@ -57,8 +56,7 @@ function Title({ projectData }: TitleProps) {
                 <T.ProjectTitle>{projectData.serviceName}</T.ProjectTitle>
                 <ProjectSummary fontSize={summaryFontSize}>
                     {projectData.description}
-                </ProjectSummary>{' '}
-                <T.ProjectContainer>
+                </ProjectSummary>                <T.ProjectContainer>
                     <T.P>{projectData.content}</T.P>
                 </T.ProjectContainer>
             </T.Content>


### PR DESCRIPTION
## 작업 내용

- 팀원, 기수, 기간, 기술 스택 실제 데이터로 변경
- 로그인 상태에서 팀원 클릭 시 유저 페이지로 이동
- fetch api -> axiosInstance 로 수정
- 프로젝트 목록으로 돌아갈 때 새로고침 제거

- 폰트 수정
- summary가 길어지는 경우, 폰트 크기를 조절하여 영역을 넘기는 문제 해결
- 서비스 바로가기 버튼 크기 균일화
- 사진 상단 여백 추가
- 로그인 상태에서 개발자 호버시에 색 변경

