### PR TITLE
Feat: 유저 정보 패칭 - react query로 변경

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -10,13 +10,11 @@ export const requestIdtoken = async (
     return await axiosInstance
         .get(`/api/v1/auth/${provider}/idtoken?code=${authorizationCode}`)
         .then(response => {
-            //idtoken return
             localStorage.setItem('idtoken', response.data.data.idToken);
-            return Promise.resolve(response.data.data.idToken);
+            return response.data.data.idToken;
         })
         .catch(error => {
-            if (axios.isAxiosError(error))
-            return undefined;
+            if (axios.isAxiosError(error)) return undefined;
         });
 };
 
@@ -39,19 +37,12 @@ export const requestLogin = async (
             return isUser;
         })
         .catch(error => {
-            if (axios.isAxiosError(error))
-            return undefined;
+            if (axios.isAxiosError(error)) return undefined;
         });
 };
 
-// 유저정보 GET
+// 유저정보 GET - 실패하거나 에러가 나면 response = undefined
 export const requestUserInfo = async () => {
-    return await axiosInstance
-        .get(`/api/v1/auth/userinfo`)
-        .then(response => {
-            return response.data;
-        })
-        .catch(error => {
-            return error;
-        });
+    const response = await axiosInstance.get(`/api/v1/auth/userinfo`);
+    return response.data;
 };

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -17,23 +17,9 @@ const Nav = () => {
     const navigate = useNavigate();
 
     // 로그인 상태
-    const [isLogin, setIsLogin] = useState<Boolean>(false);
-    const { userinfo, setUserinfo } = useAuth();
+    const { userinfo, handleLogout } = useAuth();
     // const profileSrc =
     //     userinfo.profileImage === '' ? defaultprofile : userinfo.profileImage;
-    useEffect(() => {
-        setIsLogin(userinfo.isLogin);
-    }, [userinfo]);
-    const onClickLogout = () => {
-        localStorage.clear();
-        setUserinfo({
-            name: '',
-            profileImage: '',
-            userId: -1,
-            role: '',
-            isLogin: false,
-        });
-    };
 
     // 프로필 버튼 창 상태
     const [profileModal, setProfileModal] = useState<Boolean>(false);
@@ -161,7 +147,7 @@ const Nav = () => {
                     </div>
 
                     <div className="right">
-                        {/* {isLogin ? (
+                        {/* {userinfo?.isLogin ? (
                             <>
                                 <ChatBtn to="/chat">
                                     <img src={chat} />
@@ -209,8 +195,7 @@ const Nav = () => {
                             <div
                                 onClick={() => {
                                     setProfileModal(pre => !pre);
-
-                                    onClickLogout();
+                                    handleLogout();
                                     navigate('/');
                                 }}
                                 className="inner"

--- a/src/components/ProtectedRouter.tsx
+++ b/src/components/ProtectedRouter.tsx
@@ -12,7 +12,7 @@ const ProtectedRouter = ({ children }: ProtectedRouterProp) => {
 
     useEffect(() => {
         if (!userinfo.isLogin && !isLoading) navigate('/login');
-    }, [userinfo.isLogin, isLoading]);
+    }, [userinfo.isLogin, isLoading, navigate]);
 
     return userinfo.isLogin ? <>{children}</> : null;
 };

--- a/src/components/login/Redirect.tsx
+++ b/src/components/login/Redirect.tsx
@@ -1,41 +1,58 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { userState } from '../../store/user';
-import { useSetRecoilState } from 'recoil';
+import { useQuery } from '@tanstack/react-query';
+
 import {
     requestIdtoken,
     requestLogin,
     requestUserInfo,
 } from '../../api/auth/auth';
 
+const socialLogin = async (
+    authorizationCode: string | null,
+    provider: string | undefined,
+) => {
+    const idToken = await requestIdtoken(authorizationCode, provider);
+    if (idToken === undefined) {
+        alert('Error requesting idtoken! Please Retry Login.');
+        return Error;
+    }
+
+    const isUser = await requestLogin(provider, idToken);
+    if (isUser === undefined) {
+        alert('Error requesting login! Please Retry Login.');
+        return Error;
+    }
+
+    if (isUser === true) {
+        const response = await requestUserInfo();
+        return { ...response.data, isLogin: true };
+    }
+
+    return null;
+};
+
 export const Redirect = () => {
     const navigate = useNavigate();
+
     const url = new URL(window.location.href);
     const authorizationCode = url.searchParams.get('code');
     const { provider } = useParams();
-    const updateUserState = useSetRecoilState(userState);
-    const isEffectRun = useRef(false);
+
+    const { data, error } = useQuery({
+        queryKey: ['login-user-information'],
+        queryFn: () => socialLogin(authorizationCode, provider),
+    });
 
     useEffect(() => {
-        if (isEffectRun.current) {
-            // 이미 실행되었다면 더 이상 실행하지 않도록 함
-            return;
+        if (error) {
+            navigate('/login');
+        } else if (data === null) {
+            navigate(`/signup/${provider}`);
+        } else if (data) {
+            navigate('/');
         }
-        const socialLogin = async () => {
-            const idtoken = await requestIdtoken(authorizationCode, provider);
-            const isUser = await requestLogin(provider, idtoken);
-
-            if (isUser) {
-                const response = await requestUserInfo();
-                updateUserState({ ...response.data, isLogin: true });
-                navigate('/');
-            } else {
-                navigate(`/signup/${provider}`);
-            }
-        };
-        socialLogin();
-        isEffectRun.current = true;
-    }, []);
+    }, [data, error, provider, navigate]);
 
     return <div></div>;
 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,7 +2,29 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { requestUserInfo } from '../api/auth/auth';
 
+import { userState } from '../store/user';
+import { useSetRecoilState } from 'recoil';
+import { useEffect } from 'react';
+
+type User = {
+    name: string;
+    profileImage: string;
+    userId: number;
+    role: string;
+    isLogin: boolean;
+};
+
+const fallback = {
+    name: '',
+    profileImage: '',
+    userId: -1,
+    role: '',
+    isLogin: false,
+};
+
 export const useAuth = () => {
+    const updateUserState = useSetRecoilState(userState);
+
     const access_token = localStorage.getItem('access_token');
     const queryClient = useQueryClient();
 
@@ -12,14 +34,17 @@ export const useAuth = () => {
     };
 
     const {
-        data: userinfo,
+        data: userinfo = fallback,
         isLoading,
         error,
-    } = useQuery({
+    } = useQuery<User>({
         queryKey: ['login-user-information'],
         queryFn: fetchUser,
         enabled: !!access_token,
     });
+    useEffect(() => {
+        updateUserState(userinfo);
+    }, [userinfo, updateUserState]);
 
     const handleLogout = () => {
         localStorage.clear();

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
-type UserInfo = {
+type User = {
     name: string;
     profileImage: string;
     userId: number;
@@ -8,7 +8,7 @@ type UserInfo = {
     isLogin: boolean;
 };
 
-export const userState = atom<UserInfo>({
+export const userState = atom<User>({
     key: 'userInfo',
     default: {
         name: '',


### PR DESCRIPTION
기존 axios와 recoil 사용하여 관리하던 유저정보를 react query를 사용하여 캐시에 저장하고 관리되도록 수정하였습니다.

useAuth.tsx
- 원래 방식과 동일하게 useAuth 사용하여 유저정보에 접근할 수 있습니다.
- useAuth에 로그아웃 함수를 추가하였습니다.

Redirect.tsx
- 로그인 시도 중 오류 시 메인 페이지로 돌아가도록 하였습니다.
- 유저 정보 캐시에 저장하도록 하였습니다.

*userState를 구독 중인 다른 컴포넌트가 존재하여 업데이트하도록 두었으나 후에 삭제예정입니다.*

