### PR TITLE
feat: 다른 유저 페이지 추가

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -65,7 +65,11 @@ const router = createBrowserRouter([
             },
             {
                 path: '/userpage/:user_id',
-                element: <Userpage />,
+                element: (
+                    <ProtectedRouter>
+                        <Userpage />
+                    </ProtectedRouter>
+                ),
             },
             {
                 path: '/project',
@@ -144,7 +148,6 @@ const router = createBrowserRouter([
                 ],
             },
 
-
             {
                 path: '/chat',
                 element: <Chat />,
@@ -154,7 +157,6 @@ const router = createBrowserRouter([
                 element: <AboutPage />,
             },
         ],
-       
     },
     {
         path: '/oauth/:provider/redirect',

--- a/src/api/mypage/useLoadFollow.tsx
+++ b/src/api/mypage/useLoadFollow.tsx
@@ -1,7 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { axiosInstance } from '../../utils/axios';
-import { useAuth } from '../../hooks/useAuth';
 
 interface Follow {
     currentPage: number;
@@ -21,10 +20,7 @@ async function userFollowApi(
     return response.data.data;
 }
 
-export function useLoadFollow(follow: string) {
-    const {
-        userinfo: { userId },
-    } = useAuth();
+export function useLoadFollow(userId: number, follow: string) {
     const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
         useInfiniteQuery({
             queryKey: [follow, userId],

--- a/src/api/mypage/useUserProfile.tsx
+++ b/src/api/mypage/useUserProfile.tsx
@@ -1,4 +1,8 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+    useMutation,
+    useQueryClient,
+    useSuspenseQuery,
+} from '@tanstack/react-query';
 
 import { axiosInstance } from '../../utils/axios';
 import { IuserProfile, IuserModify } from '../../components/mypage/type';
@@ -10,32 +14,14 @@ async function fetchUserProfile(user_id: number): Promise<IuserProfile> {
     return response.data.data;
 }
 
-const DEFAULT_USER_PROFILE = {
-    followerNum: 0,
-    followingNum: 0,
-    id: -1,
-    introduction: '',
-    isMine: false,
-    major: '',
-    name: '',
-    ordinal: -1,
-    part: '',
-    phoneNum: '',
-    profileImage: '',
-    role: '',
-    universityName: '',
-};
-
-export function useUserProfile() {
-    const {
-        userinfo: { userId },
-    } = useAuth();
-    const { data: userProfile = DEFAULT_USER_PROFILE } = useQuery({
-        queryKey: ['user-profile', userId],
-        queryFn: () => fetchUserProfile(userId),
+export function useUserProfile(user_id: number) {
+    const { data: userProfile, error } = useSuspenseQuery({
+        queryKey: ['user-profile', user_id],
+        queryFn: () => fetchUserProfile(user_id),
+        retry: 0,
     });
 
-    return userProfile;
+    return { userProfile, error };
 }
 
 async function updateUserProfile(user_id: number, user_info: IuserModify) {

--- a/src/components/mypage/FollowBox.tsx
+++ b/src/components/mypage/FollowBox.tsx
@@ -1,11 +1,21 @@
-import styled, { css } from 'styled-components';
-import { Avatar, Button, convertPart } from './Common';
-import { Ifollows } from './type';
 import { useState } from 'react';
+import styled, { css } from 'styled-components';
+
+import { Avatar, Button, convertPart } from './Common';
 import { useFollowAddDelete } from '../../api/mypage/useFollowAddDelete';
 
 interface IbuttonProps {
     delete: boolean;
+}
+
+export interface Ifollows {
+    userId: number;
+    name: string;
+    profileImage: string | null;
+    ordinal: number;
+    part: string;
+    isFollowed: boolean;
+    isMine: boolean;
 }
 
 export const FollowBox = ({
@@ -15,6 +25,7 @@ export const FollowBox = ({
     part,
     profileImage,
     isFollowed,
+    isMine,
 }: Ifollows) => {
     const [isFollow, setisFollow] = useState(isFollowed);
     const { mutate: handleFollowAddDelete } = useFollowAddDelete(
@@ -33,14 +44,16 @@ export const FollowBox = ({
                     </p>
                 </FollowProfile>
             </FollowInfo>
-            <FollowBtn
-                delete={isFollow}
-                onClick={() => {
-                    handleFollowAddDelete(isFollow);
-                }}
-            >
-                {isFollow ? '삭제' : '팔로우'}
-            </FollowBtn>
+            {isMine && (
+                <FollowBtn
+                    delete={isFollow}
+                    onClick={() => {
+                        handleFollowAddDelete(isFollow);
+                    }}
+                >
+                    {isFollow ? '삭제' : '팔로우'}
+                </FollowBtn>
+            )}
         </Follow>
     );
 };

--- a/src/components/mypage/FollowModal.tsx
+++ b/src/components/mypage/FollowModal.tsx
@@ -20,7 +20,7 @@ export const FollowModal = ({
     const modalRef = useRef<HTMLDivElement>(null);
     const follow = modalProps.follow === '팔로워' ? 'follower' : 'following';
     const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
-        useLoadFollow(follow);
+        useLoadFollow(modalProps.userid, follow);
 
     const ref = useIntersect(async (entry, observer) => {
         observer.unobserve(entry.target);
@@ -47,6 +47,7 @@ export const FollowModal = ({
                                 part={item['part']}
                                 profileImage={item['profileImage']}
                                 isFollowed={item['isFollowed']}
+                                isMine={modalProps.isMine}
                             />
                         )),
                     )}

--- a/src/components/mypage/MUserProfile.tsx
+++ b/src/components/mypage/MUserProfile.tsx
@@ -22,14 +22,14 @@ const USER_ROLE: { [id: string]: string } = {
 
 function MUserProfile({ userProfile }: UserProfileProps) {
     const { isModalOpen, openModal, closeModal } = useModal();
-    const [modalProps, setModalProps] = useState<ImodalProps>({
-        userid: -1,
+    const [modalProps, setModalProps] = useState<ImodalProps>(() => ({
+        userid: userProfile.id,
         follow: '',
-    });
+        isMine: userProfile.isMine,
+    }));
     const handleModal = (e: React.MouseEvent<HTMLDivElement>) => {
         let follow = e.currentTarget.dataset.type;
-        let userid = userProfile.id;
-        setModalProps({ userid, follow });
+        setModalProps({ ...modalProps, follow });
         openModal();
     };
 

--- a/src/components/mypage/ResponsiveUserBox.tsx
+++ b/src/components/mypage/ResponsiveUserBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 import useIsPC from '../../hooks/useIsPC';
@@ -8,12 +8,21 @@ import { Avatar } from './Common';
 import UserProfile from './UserProfile';
 import MUserProfile from './MUserProfile';
 import { UserDescription } from './UserProfile.style';
-import { IuserProfile } from './type';
+import { useAuth } from '../../hooks/useAuth';
 
-function ResponsiveUserBox() {
-    // 프로필 정보 받기
+type ResponsiveUserBoxProps = {
+    otherUserId?: number | null;
+};
+
+function ResponsiveUserBox({ otherUserId = null }: ResponsiveUserBoxProps) {
     const isPC = useIsPC();
-    const userProfile: IuserProfile = useUserProfile();
+    //prettier-ignore
+    const { userinfo: { userId } } = useAuth();
+
+    const requestId = otherUserId || userId;
+
+    // 등록되지 않은 유저인 경우 axios.ts에서 에러 처리하여 이전 페이지로 되돌리고 있음.
+    const { userProfile } = useUserProfile(requestId);
 
     return (
         <>

--- a/src/components/mypage/UserInfomation.tsx
+++ b/src/components/mypage/UserInfomation.tsx
@@ -1,19 +1,27 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
 import ResponsiveUserBox from './ResponsiveUserBox';
 import { Button } from './Common';
 
-function UserInfomation() {
+type UserInfoProps = {
+    otherUserId?: number | null;
+};
+
+function UserInfomation({ otherUserId = null }: UserInfoProps) {
     const navigate = useNavigate();
 
     return (
         <Container>
-            <ResponsiveUserBox />
-            <ResponsiveButton onClick={() => navigate('modify')}>
-                내 정보 수정
-            </ResponsiveButton>
+            <Suspense fallback={<div>Loading...</div>}>
+                <ResponsiveUserBox otherUserId={otherUserId} />
+            </Suspense>
+            {!otherUserId && (
+                <ResponsiveButton onClick={() => navigate('modify')}>
+                    내 정보 수정
+                </ResponsiveButton>
+            )}
         </Container>
     );
 }

--- a/src/components/mypage/UserProfile.tsx
+++ b/src/components/mypage/UserProfile.tsx
@@ -21,14 +21,18 @@ const USER_ROLE: { [id: string]: string } = {
 
 function UserProfile({ userProfile }: UserProfileProps) {
     const { isModalOpen, openModal, closeModal } = useModal();
-    const [modalProps, setModalProps] = useState<ImodalProps>({
-        userid: -1,
+    const [modalProps, setModalProps] = useState<ImodalProps>(() => ({
+        userid: userProfile.id,
         follow: '',
-    });
+        isMine: userProfile.isMine,
+    }));
+
+    console.log(userProfile);
+
     const handleModal = (e: React.MouseEvent<HTMLDivElement>) => {
         let follow = e.currentTarget.dataset.type;
-        let userid = userProfile.id;
-        setModalProps({ userid, follow });
+        setModalProps(() => ({ ...modalProps, follow }));
+        console.log(modalProps);
         openModal();
     };
 

--- a/src/components/mypage/type.tsx
+++ b/src/components/mypage/type.tsx
@@ -79,15 +79,7 @@ export interface IuserProfile {
 export interface ImodalProps {
     userid: number;
     follow: string | undefined;
-}
-
-export interface Ifollows {
-    userId: number;
-    name: string;
-    profileImage: string | null;
-    ordinal: number;
-    part: string;
-    isFollowed: boolean;
+    isMine: boolean;
 }
 
 export interface IuserModify {

--- a/src/routes/Userpage.tsx
+++ b/src/routes/Userpage.tsx
@@ -1,10 +1,14 @@
+import { useParams } from 'react-router-dom';
+
 import UserInfomation from '../components/mypage/UserInfomation';
 import UserPost from '../components/mypage/UserPost';
 
 const Userpage = () => {
+    let { user_id } = useParams();
+    let userId = Number(user_id);
     return (
         <>
-            <UserInfomation />
+            <UserInfomation otherUserId={userId} />
             <UserPost />
         </>
     );

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -70,6 +70,13 @@ axiosInstance.interceptors.response.use(
             return axiosInstance(originRequest);
         }
 
+        // 등록되지 않은 유저에 대한 요청일 시 바로 이전 페이지로 이동
+        if (axiosError?.code === 'USER_404') {
+            alert(axiosError.message);
+            window.history.back();
+            return Promise.reject(error);
+        }
+
         alert(axiosError?.message);
         return Promise.reject(error);
     },


### PR DESCRIPTION
/userpage/:user_id에 해당 유저 아이디의 프로필이 보이도록 컴포넌트 수정

axios.ts
- USER_404일 때 에러 핸들링 코드 추가했습니다. (등록되지 않은 유저에 대한 요청일 경우 직전 페이지로 이동)

아래 항목 제외하고 마이페이지와 UI 동일합니다.
1. 정보 수정 버튼 없음
2. 팔로워/팔로잉 모달 창에서 팔로잉/삭제 버튼 없음