### PR TITLE
Fix:랜딩페이지 제목 중앙정렬 수정

### DIFF
--- a/src/pages/landing/components/MainGraphic.style.ts
+++ b/src/pages/landing/components/MainGraphic.style.ts
@@ -276,6 +276,9 @@ export const Description = styled.div`
         @media (max-width: 768px) {
             font-size: 28px;
         }
+        @media (max-width: 480px) {
+            font-size: 6.2vw;
+        }
 
         svg {
             margin-right: 10px;
@@ -288,6 +291,12 @@ export const Description = styled.div`
                 width: 24px;
                 height: 24px;
                 margin-right: 5px;
+            }
+
+            @media (max-width: 480px) {
+                width: 6.44vw;
+                height: 6.4vw;
+                margin-right: 1.5%;
             }
         }
     }


### PR DESCRIPTION
## **Pull Request**

### ✨ 작업 내용
- 480px 이하의 디바이스에서도 메인페이지의 제목을 가운데 정렬 가능하도록 변경

---

### ✨ 참고 사항

---

### ⏰ 현재 버그
X
---

### ✏ Git Close
X (다들 확인하신 뒤 수정하겠습니다!)