### PR TITLE
메인페이지 제목 중앙 정렬

### DIFF
--- a/src/pages/landing/components/MainGraphic.style.ts
+++ b/src/pages/landing/components/MainGraphic.style.ts
@@ -276,6 +276,9 @@ export const Description = styled.div`
         @media (max-width: 768px) {
             font-size: 28px;
         }
+        @media (max-width: 480px) {
+            font-size: 6.2vw;
+        }
 
         svg {
             margin-right: 10px;
@@ -288,6 +291,12 @@ export const Description = styled.div`
                 width: 24px;
                 height: 24px;
                 margin-right: 5px;
+            }
+
+            @media (max-width: 480px) {
+                width: 6.4vw;
+                height: 6.4vw;
+                margin-right: 1.5%;
             }
         }
     }

--- a/src/pages/landing/components/MainGraphic.style.ts
+++ b/src/pages/landing/components/MainGraphic.style.ts
@@ -276,6 +276,9 @@ export const Description = styled.div`
         @media (max-width: 768px) {
             font-size: 28px;
         }
+        @media (max-width: 480px) {
+            font-size: 6.2vw;
+        }
 
         svg {
             margin-right: 10px;
@@ -288,6 +291,12 @@ export const Description = styled.div`
                 width: 24px;
                 height: 24px;
                 margin-right: 5px;
+            }
+
+            @media (max-width: 480px) {
+                width: 6.44vw;
+                height: 6.4vw;
+                margin-right: 1.5%;
             }
         }
     }


### PR DESCRIPTION
## **Pull Request**

### ✨ 작업 내용

- 480px 이하의 모바일 디바이스에서도 메인페이지 제목 중앙에 보일 수 있도록 수정 

---

### ✨ 참고 사항

![image](https://github.com/LikelionUniv/LikelionUniv_Frontend_University/assets/105477246/a915c87c-5ce0-43ce-b294-f3dc33873b75)


---

### ⏰ 현재 버그

X
---

### ✏ Git Close

X(확인하시면 수정하겠습니다!)