### PR TITLE
해커톤 랜딩 페이지 기본 구조도 세팅 

### DIFF
--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -4,7 +4,7 @@
 import HakathonLanding from './components/hakathon/HakathonLanding';
 
 const LandingPage = () => {
-    // return <Landing />;
+    // return <Landing />; // 추후 랜딩 페이지에 관련해서 해커톤 기간이 끝나면 다시 되돌릴 계획입니다.
     return <HakathonLanding />;
 };
 

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -1,9 +1,11 @@
 //import '../components/LoadScript';
 
-import Landing from './components/Landing';
+// import Landing from './components/Landing';
+import HakathonLanding from './components/hakathon/HakathonLanding';
 
 const LandingPage = () => {
-    return <Landing />;
+    // return <Landing />;
+    return <HakathonLanding />;
 };
 
 export default LandingPage;

--- a/src/pages/landing/components/hakathon/HakathonLanding.tsx
+++ b/src/pages/landing/components/hakathon/HakathonLanding.tsx
@@ -1,0 +1,11 @@
+import { Layout, Container } from '../../../../styles/Layout';
+
+const HakathonLanding = () => {
+    return (
+        <Layout>
+            <Container>{/*여기서 이제 컴포넌트 작성하면 됩니다.*/}</Container>
+        </Layout>
+    );
+};
+
+export default HakathonLanding;

--- a/src/styles/Layout.ts
+++ b/src/styles/Layout.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const Layout = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    width: 100vw;
+`;
+
+export const Container = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    width: 100%;
+    max-width: 1920px;
+    margin-top: 56px;
+    height: 1000px; // 임시로 세팅해놓은 값이기때문에 어느정도 완성되면 지워도 됩니다.
+    /* border: 1px solid black; */
+`;


### PR DESCRIPTION
## **Pull Request**

### ✨ 작업 내용

---

- 1920px 기준으로 화면 구조 세팅 완료하였습니다.

### ✨ 참고 사항

---

<img width="1327" alt="image" src="https://github.com/LikelionUniv/LikelionUniv_Frontend_University/assets/48755156/9d494c06-d5b7-44da-a216-dc4b64db7c91">


### ⏰ 현재 버그

---

x

### ✏ Git Close

close #74 