### PR TITLE
userid 수정 교체

### DIFF
--- a/src/pages/mypage/components/MUserProfile.tsx
+++ b/src/pages/mypage/components/MUserProfile.tsx
@@ -22,13 +22,26 @@ const USER_ROLE: { [id: string]: string } = {
 function MUserProfile({ userProfile }: UserProfileProps) {
     const { isModalOpen, openModal, closeModal } = useModal();
     const [modalProps, setModalProps] = useState<ImodalProps>(() => ({
-        userid: userProfile.id,
+        userid: -1,
         follow: '',
         isMine: userProfile.isMine,
     }));
+
+    useEffect(() => {
+        if (userProfile.id) {
+            setModalProps(prevModalProps => ({
+                ...prevModalProps,
+                userid: userProfile.id,
+            }));
+        }
+    }, [userProfile.id]);
+
     const handleModal = (e: React.MouseEvent<HTMLDivElement>) => {
         let follow = e.currentTarget.dataset.type;
-        setModalProps({ ...modalProps, follow });
+        setModalProps(prevModalProps => ({
+            ...prevModalProps,
+            follow,
+        }));
         openModal();
     };
 


### PR DESCRIPTION
## **Pull Request**

### ✨ 작업 내용

---

- 마이페이지 내에서 팔로잉 버튼을 눌렀을 시 user_id값을 받아오도록 수정

### ✨ 참고 사항

---

<img width="167" alt="image" src="https://github.com/user-attachments/assets/c0765fc2-edbf-47b1-af60-c31595ca308d" />

- modalProps라는 함수가 리렌더링 3번 정도 일어나게 되면서 props로 넘길때 useState의 초기값을 받기전에 렌더링 되어버림.

```
 const [modalProps, setModalProps] = useState<ImodalProps>(() => ({
        userid: -1,
        follow: '',
        isMine: userProfile.isMine,
    }));

    useEffect(() => {
        if (userProfile.id) {
            setModalProps(prevModalProps => ({
                ...prevModalProps,
                userid: userProfile.id,
            }));
        }
    }, [userProfile.id]);
```

초기값을 받고 다시 값을 변경해주는 것으로 변경

### ⏰ 현재 버그

---

x

### ✏ Git Close