### PR TITLE
cardStyle에 따른 1대1 사진 비율 유지

### DIFF
--- a/src/pages/mypage/components/PostCardStyle.tsx
+++ b/src/pages/mypage/components/PostCardStyle.tsx
@@ -157,7 +157,8 @@ export const PostCardBox = styled.div<PhotoCheck>`
     }
     &.photo {
         background-repeat: no-repeat;
-        background-size: 100% 100%;
+        background-position: center;
+        background-size: contain;
         z-index: 10;
         margin-bottom: 16px;
         @media (min-width: 1281px) {


### PR DESCRIPTION
## **Pull Request**

### ✨ 작업 내용

---

<img width="430" alt="image" src="https://github.com/user-attachments/assets/d9617deb-a858-4bce-8738-d7a652605eef" />

- 1대1 비율로 사진 넣을시 비율 유지 하도록 변경

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close

close #143 